### PR TITLE
report actual version on CLI

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,6 +5,8 @@ module Main where
 
 import ConditionalRestriction (ID, Result (Err, Ok), Type (TBool, TNum, TTime), evaluate, needsData, parseRestriction)
 import Control.Monad (unless, when)
+import Data.Version (showVersion)
+import Paths_conditional_restriction_parser (version)
 import System.Console.CmdArgs
   ( CmdArgs,
     Data,
@@ -64,7 +66,7 @@ programModes =
           &= help "List the data needed to evaluate this conditional restriction."
       ]
       &= program "conditional-restriction-parser-exe"
-      &= summary "Conditional Restriction Parser v0.1.0.0, (C) Lukas Buchli 2022"
+      &= summary ("Conditional Restriction Parser " ++ showVersion version ++ ", (C) Lukas Buchli 2022")
 
 main :: IO ()
 main =


### PR DESCRIPTION
getting it from a cabal-generated module as shown in [this answer](https://stackoverflow.com/a/2892624/674064) to "[How can my Haskell program or library find its version number?](https://stackoverflow.com/q/2892586/674064)"